### PR TITLE
feat: Integrate swagger in the data project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
             <version>4.0.0-M1</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/java/test/junior/configuration/OpenApiConfig.java
+++ b/src/main/java/com/java/test/junior/configuration/OpenApiConfig.java
@@ -1,0 +1,17 @@
+package com.java.test.junior.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public io.swagger.v3.oas.models.OpenAPI customOpenAPI() {
+        return new io.swagger.v3.oas.models.OpenAPI()
+                .info(new io.swagger.v3.oas.models.info.Info()
+                        .title("Java Test Junior API")
+                        .version("1.0")
+                        .description("API documentation for the Junior Test project."));
+    }
+}

--- a/src/main/java/com/java/test/junior/configuration/SecurityConfig.java
+++ b/src/main/java/com/java/test/junior/configuration/SecurityConfig.java
@@ -18,6 +18,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable()) // Disable CSRF for testing with Postman
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/auth/**").permitAll()
                         .requestMatchers("/error").permitAll()
                         .requestMatchers("/products/**").authenticated()

--- a/src/main/java/com/java/test/junior/controller/AuthController.java
+++ b/src/main/java/com/java/test/junior/controller/AuthController.java
@@ -4,20 +4,23 @@ import com.java.test.junior.model.UserDTO;
 import com.java.test.junior.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 @Validated
+@Tag(name = "Authentication", description = "Authentication-related endpoints")
 public class AuthController {
     private final UserService userService;
 
     @PostMapping("/register")
+    @Operation(summary = "Register a new user")
+    @ResponseStatus(HttpStatus.CREATED)
     public void register(@Valid @RequestBody UserDTO userDTO) {
         userService.save(userDTO);
     }

--- a/src/main/java/com/java/test/junior/controller/ProductController.java
+++ b/src/main/java/com/java/test/junior/controller/ProductController.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
@@ -23,53 +25,62 @@ import java.util.List;
 @RequestMapping("/products")
 @RequiredArgsConstructor
 @Validated
+@Tag(name = "Products", description = "Product-related endpoints")
 public class ProductController {
     private final ProductService productService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Create a new product")
     public ProductDTO createProduct(@Valid @RequestBody ProductDTO productDTO) {
         return productService.createProduct(productDTO);
     }
 
     @GetMapping("/{id}")
     @ResponseStatus(HttpStatus.ACCEPTED)
+    @Operation(summary = "Get a product by id")
     public ProductDTO getProductById(@PathVariable Long id) {
         return productService.getProductById(id);
     }
 
     @PutMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Update a product by id")
     public void updateProduct(@PathVariable Long id, @Valid @RequestBody ProductDTO productDTO) {
         productService.modifyProductById(id, productDTO);
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Delete a product by id")
     public void deleteProduct(@PathVariable Long id) {
         productService.deleteProductById(id);
     }
 
     @GetMapping()
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Get products paginated")
     public List<ProductDTO> getPaginatedProducts(@RequestParam("page") int page, @RequestParam("page_size") int size) {
         return productService.getPaginatedProducts(page, size);
     }
 
     @GetMapping("name/{name}")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Get product by name")
     public ProductDTO getProductByName(@PathVariable String name) {
         return productService.getProductByName(name);
     }
 
     @PostMapping("/{id}/like")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Like a product")
     public void likeProduct(@PathVariable Long id) {
         productService.likeProduct(id);
     }
 
     @PostMapping("{id}/dislike")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Dislike a product")
     public void dislikeProduct(@PathVariable Long id) {
         productService.dislikeProduct(id);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,4 @@ server.port=8080
 # Logging (helpful for debugging)
 logging.level.com.java.test.junior.mapper=DEBUG
 logging.level.org.springframework.jdbc=DEBUG
+


### PR DESCRIPTION
This pull request introduces OpenAPI/Swagger documentation to the project and updates the controllers to include API documentation annotations. It also adjusts security settings to allow access to the API documentation endpoints. These changes improve the project's API discoverability and usability for developers and external consumers.

**API Documentation Integration:**

* Added the `springdoc-openapi-starter-webmvc-ui` dependency in `pom.xml` to enable Swagger/OpenAPI support.
* Created `OpenApiConfig.java` to configure OpenAPI metadata such as title, version, and description.

**Controller Documentation Enhancements:**

* Annotated `AuthController` and `ProductController` endpoints with OpenAPI annotations (`@Tag`, `@Operation`) to provide detailed API documentation. [[1]](diffhunk://#diff-1d5c78bd77766891640b0916e910c9ea6d457760fc7228572b52769f3505f872R7-R23) [[2]](diffhunk://#diff-63edfec3c191b368dc3e2d05eb1a18705c33f3c82cfef81f4feb6c952d2c9ed6R14-R15) [[3]](diffhunk://#diff-63edfec3c191b368dc3e2d05eb1a18705c33f3c82cfef81f4feb6c952d2c9ed6R28-R83)

**Security Configuration Updates:**

* Updated `SecurityConfig.java` to allow unauthenticated access to Swagger/OpenAPI endpoints (`/v3/api-docs/**`, `/swagger-ui/**`, `/swagger-ui.html`).

**Minor Changes:**

* Minor formatting update in `application.properties`.