### PR TITLE
Fix/milestone4

### DIFF
--- a/src/main/java/com/java/test/junior/configuration/OpenApiConfig.java
+++ b/src/main/java/com/java/test/junior/configuration/OpenApiConfig.java
@@ -18,6 +18,6 @@ public class OpenApiConfig {
                         .description("API documentation for the Junior Test project."))
                         .addSecurityItem(new SecurityRequirement().addList("JavaTestJuniorScheme"))
                         .components(new Components().addSecuritySchemes("JavaTestJuniorScheme", new SecurityScheme()
-                        .name("JavaTestJuniorScheme").type(SecurityScheme.Type.HTTP).scheme("basic")));
+                        .name("JavaTestScheme").type(SecurityScheme.Type.HTTP).scheme("basic")));
     }
 }

--- a/src/main/java/com/java/test/junior/configuration/SecurityConfig.java
+++ b/src/main/java/com/java/test/junior/configuration/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.java.test.junior.configuration;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -23,6 +24,11 @@ public class SecurityConfig {
                         .requestMatchers("/error").permitAll()
                         .requestMatchers(HttpMethod.GET, "/products/**").permitAll()
                         .requestMatchers("/products/**").authenticated()
+                )
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Access Denied");
+                        })
                 )
                 .httpBasic(Customizer.withDefaults());
 


### PR DESCRIPTION
This pull request enhances API security and updates access control for the `products` endpoints. It introduces HTTP Basic authentication to the OpenAPI documentation and allows unauthenticated GET requests to `/products/**`, while securing other product-related endpoints. Additionally, it improves exception handling for authentication failures.

**API Security and Documentation:**

* Added HTTP Basic authentication scheme to the OpenAPI documentation and required it for secured endpoints. (`OpenApiConfig.java`) [[1]](diffhunk://#diff-002cd33487263c28c17b8b3cb0013abd5e91c07a70cf247c2c777d76ec06647fR3-R5) [[2]](diffhunk://#diff-002cd33487263c28c17b8b3cb0013abd5e91c07a70cf247c2c777d76ec06647fL15-R21)

**Access Control and Exception Handling:**

* Updated security configuration to permit unauthenticated GET requests to `/products/**`, while requiring authentication for other requests to `/products/**`. (`SecurityConfig.java`)
* Improved exception handling to return a 403 Forbidden error with "Access Denied" message when authentication fails. (`SecurityConfig.java`)
* Added necessary import for `jakarta.servlet.http.HttpServletResponse`. (`SecurityConfig.java`)