### PR TITLE
fix: Move handler and exceptions in the controller package

### DIFF
--- a/src/main/java/com/java/test/junior/controller/FileNotFoundException.java
+++ b/src/main/java/com/java/test/junior/controller/FileNotFoundException.java
@@ -1,4 +1,4 @@
-package com.java.test.junior.exception;
+package com.java.test.junior.controller;
 
 public class FileNotFoundException extends RuntimeException {
     public FileNotFoundException(String message) {

--- a/src/main/java/com/java/test/junior/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/java/test/junior/controller/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.java.test.junior.exception;
+package com.java.test.junior.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/src/main/java/com/java/test/junior/controller/IllegalArgumentException.java
+++ b/src/main/java/com/java/test/junior/controller/IllegalArgumentException.java
@@ -1,4 +1,4 @@
-package com.java.test.junior.exception;
+package com.java.test.junior.controller;
 
 public class IllegalArgumentException extends RuntimeException{
     public IllegalArgumentException(String message) {

--- a/src/main/java/com/java/test/junior/controller/ProductNotFoundException.java
+++ b/src/main/java/com/java/test/junior/controller/ProductNotFoundException.java
@@ -1,4 +1,4 @@
-package com.java.test.junior.exception;
+package com.java.test.junior.controller;
 
 public class ProductNotFoundException extends RuntimeException{
     public ProductNotFoundException(String message) {

--- a/src/main/java/com/java/test/junior/controller/UserAlreadyExistsException.java
+++ b/src/main/java/com/java/test/junior/controller/UserAlreadyExistsException.java
@@ -1,4 +1,4 @@
-package com.java.test.junior.exception;
+package com.java.test.junior.controller;
 
 public class UserAlreadyExistsException extends RuntimeException{
     public UserAlreadyExistsException(String message) {

--- a/src/main/java/com/java/test/junior/controller/UserNotFoundException.java
+++ b/src/main/java/com/java/test/junior/controller/UserNotFoundException.java
@@ -1,4 +1,4 @@
-package com.java.test.junior.exception;
+package com.java.test.junior.controller;
 
 public class UserNotFoundException extends RuntimeException{
     public UserNotFoundException(String message) {

--- a/src/main/java/com/java/test/junior/controller/UserNotLoggedInException.java
+++ b/src/main/java/com/java/test/junior/controller/UserNotLoggedInException.java
@@ -1,4 +1,4 @@
-package com.java.test.junior.exception;
+package com.java.test.junior.controller;
 
 public class UserNotLoggedInException extends RuntimeException {
     public UserNotLoggedInException(String message) {

--- a/src/main/java/com/java/test/junior/service/ProductServiceImpl.java
+++ b/src/main/java/com/java/test/junior/service/ProductServiceImpl.java
@@ -4,10 +4,10 @@
 
 package com.java.test.junior.service;
 
-import com.java.test.junior.exception.FileNotFoundException;
-import com.java.test.junior.exception.IllegalArgumentException;
-import com.java.test.junior.exception.ProductNotFoundException;
-import com.java.test.junior.exception.UserNotLoggedInException;
+import com.java.test.junior.controller.FileNotFoundException;
+import com.java.test.junior.controller.IllegalArgumentException;
+import com.java.test.junior.controller.ProductNotFoundException;
+import com.java.test.junior.controller.UserNotLoggedInException;
 import com.java.test.junior.mapper.InteractionMapper;
 import com.java.test.junior.mapper.ProductMapper;
 import com.java.test.junior.mapper.UserMapper;

--- a/src/main/java/com/java/test/junior/service/UserServiceImpl.java
+++ b/src/main/java/com/java/test/junior/service/UserServiceImpl.java
@@ -1,7 +1,7 @@
 package com.java.test.junior.service;
 
-import com.java.test.junior.exception.UserAlreadyExistsException;
-import com.java.test.junior.exception.UserNotFoundException;
+import com.java.test.junior.controller.UserAlreadyExistsException;
+import com.java.test.junior.controller.UserNotFoundException;
 import com.java.test.junior.mapper.UserMapper;
 import com.java.test.junior.model.User;
 import com.java.test.junior.model.UserDTO;


### PR DESCRIPTION
This pull request reorganizes the exception handling structure in the project by moving all custom exception classes and the global exception handler from the `exception` package to the `controller` package. Additionally, all relevant imports throughout the codebase have been updated to reflect this new package structure.

Key changes:

**Exception class and handler relocation:**
* Moved all custom exception classes (`FileNotFoundException`, `IllegalArgumentException`, `ProductNotFoundException`, `UserAlreadyExistsException`, `UserNotFoundException`, and `UserNotLoggedInException`) from the `exception` package to the `controller` package. [[1]](diffhunk://#diff-0512d091b12535e8308bb35b66bfe76305646b67ac4aff2a31799b770d47ebadL1-R1) [[2]](diffhunk://#diff-62993566b3a0216fd7f14fc2c48dd21bf8b35790abe31bd317aaa3d488183f1fL1-R1) [[3]](diffhunk://#diff-b122ba45e868e0128a81c7b1fcb93a33916ab20c8b86e8d2d83fa605a8cfd53eL1-R1) [[4]](diffhunk://#diff-dc3f2f0d7dd998ff421981e55fc6ab11a7bc32ed0cbe2e9fa43148d4b4297df4L1-R1) [[5]](diffhunk://#diff-a9638f0303f218b02b4e05b237eddb51fa445bae5f08154958cebff9222bee6aL1-R1) [[6]](diffhunk://#diff-263ed6f43d95409e966b7f1e99a47a258b7c1f21cfc30526cdbf2644e612479fL1-R1)
* Moved `GlobalExceptionHandler` from the `exception` package to the `controller` package.

**Codebase import updates:**
* Updated all imports in `ProductServiceImpl.java` and `UserServiceImpl.java` to reference the new location of the exception classes in the `controller` package. [[1]](diffhunk://#diff-ae598862cba86814f7da5c098d53694d2ddc175771c8b7afdb4c489d016fa995L7-R10) [[2]](diffhunk://#diff-25391a8684e08fd1c01b41534073cb5515164405c6ce404a0b75cd8872798310L3-R4)