### PR TITLE
fix: Correct package naming for exceptions

### DIFF
--- a/src/main/java/com/java/test/junior/controller/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/java/test/junior/controller/handler/GlobalExceptionHandler.java
@@ -1,12 +1,12 @@
 package com.java.test.junior.controller.handler;
 
 import com.java.test.junior.controller.*;
-import com.java.test.junior.controller.FileNotFoundException;
-import com.java.test.junior.controller.IllegalArgumentException;
-import com.java.test.junior.controller.ProductNotFoundException;
-import com.java.test.junior.controller.UserAlreadyExistsException;
-import com.java.test.junior.controller.UserNotFoundException;
-import com.java.test.junior.controller.UserNotLoggedInException;
+import com.java.test.junior.exception.FileNotFoundException;
+import com.java.test.junior.exception.IllegalArgumentException;
+import com.java.test.junior.exception.ProductNotFoundException;
+import com.java.test.junior.exception.UserAlreadyExistsException;
+import com.java.test.junior.exception.UserNotFoundException;
+import com.java.test.junior.exception.UserNotLoggedInException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -32,7 +32,7 @@ public class GlobalExceptionHandler {
         return ex.getMessage();
     }
 
-    @ExceptionHandler(com.java.test.junior.controller.IllegalArgumentException.class)
+    @ExceptionHandler(com.java.test.junior.exception.IllegalArgumentException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public String handleIllegalArgument(IllegalArgumentException ex) {
         return ex.getMessage();

--- a/src/main/java/com/java/test/junior/exception/FileNotFoundException.java
+++ b/src/main/java/com/java/test/junior/exception/FileNotFoundException.java
@@ -1,4 +1,4 @@
-package com.java.test.junior.controller;
+package com.java.test.junior.exception;
 
 public class FileNotFoundException extends RuntimeException {
     public FileNotFoundException(String message) {

--- a/src/main/java/com/java/test/junior/exception/IllegalArgumentException.java
+++ b/src/main/java/com/java/test/junior/exception/IllegalArgumentException.java
@@ -1,4 +1,4 @@
-package com.java.test.junior.controller;
+package com.java.test.junior.exception;
 
 public class IllegalArgumentException extends RuntimeException{
     public IllegalArgumentException(String message) {

--- a/src/main/java/com/java/test/junior/exception/ProductNotFoundException.java
+++ b/src/main/java/com/java/test/junior/exception/ProductNotFoundException.java
@@ -1,4 +1,4 @@
-package com.java.test.junior.controller;
+package com.java.test.junior.exception;
 
 public class ProductNotFoundException extends RuntimeException{
     public ProductNotFoundException(String message) {

--- a/src/main/java/com/java/test/junior/exception/UserAlreadyExistsException.java
+++ b/src/main/java/com/java/test/junior/exception/UserAlreadyExistsException.java
@@ -1,4 +1,4 @@
-package com.java.test.junior.controller;
+package com.java.test.junior.exception;
 
 public class UserAlreadyExistsException extends RuntimeException{
     public UserAlreadyExistsException(String message) {

--- a/src/main/java/com/java/test/junior/exception/UserNotFoundException.java
+++ b/src/main/java/com/java/test/junior/exception/UserNotFoundException.java
@@ -1,4 +1,4 @@
-package com.java.test.junior.controller;
+package com.java.test.junior.exception;
 
 public class UserNotFoundException extends RuntimeException{
     public UserNotFoundException(String message) {

--- a/src/main/java/com/java/test/junior/exception/UserNotLoggedInException.java
+++ b/src/main/java/com/java/test/junior/exception/UserNotLoggedInException.java
@@ -1,4 +1,4 @@
-package com.java.test.junior.controller;
+package com.java.test.junior.exception;
 
 public class UserNotLoggedInException extends RuntimeException {
     public UserNotLoggedInException(String message) {


### PR DESCRIPTION
This pull request refactors the exception handling in the project by moving custom exception classes from the `controller` package to a new `exception` package. It also updates the `GlobalExceptionHandler` to reference the new package locations. These changes help improve code organization and maintainability.

**Exception class refactoring:**

* Moved `FileNotFoundException`, `IllegalArgumentException`, `ProductNotFoundException`, `UserAlreadyExistsException`, `UserNotFoundException`, and `UserNotLoggedInException` from the `controller` package to the `exception` package, updating their package declarations accordingly. [[1]](diffhunk://#diff-5fa393c903cac16cce0cf678df4ad1f99c5f499b07dc70df0ee4f3804de73c2bL1-R1) [[2]](diffhunk://#diff-a782c76c8db36f5dbee8fb91749618443bda0b879bfef022946554a1ffd2f867L1-R1) [[3]](diffhunk://#diff-83216cb6ec5443e2a0fd764a5eba793eb2bfd52a966a75957d4d61dcb8a295a3L1-R1) [[4]](diffhunk://#diff-bef1b1aacadd4e3d033a8f57bde495e325dab06c71bc70675e917b3cf88570ebL1-R1) [[5]](diffhunk://#diff-3578eccf92dbeae0b3546144eeebe27d775e1f3580ebb1fae55c45f3bba410ebL1-R1) [[6]](diffhunk://#diff-4d13d2896962178163ddc2a681816e3d57f77a6754b0b4ef23d90f3bd86a2c68L1-R1)

**Global exception handler update:**

* Updated all import statements in `GlobalExceptionHandler.java` to reference exception classes from the new `exception` package instead of the `controller` package.
* Changed the `@ExceptionHandler` annotation in `GlobalExceptionHandler.java` for `IllegalArgumentException` to use the new package location.