### PR TITLE
fix: Create user id as fk for product and save it correctly

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="marketplace@localhost" uuid="2194bdda-b9de-40b6-b786-d13bbd373ba6">
+      <driver-ref>postgresql</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.postgresql.Driver</jdbc-driver>
+      <jdbc-url>jdbc:postgresql://localhost:5432/marketplace</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+  </component>
+</project>

--- a/src/main/java/com/java/test/junior/controller/AuthController.java
+++ b/src/main/java/com/java/test/junior/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.java.test.junior.controller;
 
-import com.java.test.junior.model.UserDTO;
+import com.java.test.junior.model.UserRegistrationDTO;
+import com.java.test.junior.model.UserResponseDTO;
 import com.java.test.junior.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,8 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.security.Principal;
 
 @RestController
 @RequestMapping("/auth")
@@ -21,7 +24,7 @@ public class AuthController {
     @PostMapping("/register")
     @Operation(summary = "Register a new user")
     @ResponseStatus(HttpStatus.CREATED)
-    public void register(@Valid @RequestBody UserDTO userDTO) {
-        userService.save(userDTO);
+    public UserResponseDTO register(@Valid @RequestBody UserRegistrationDTO userRegistrationDTO) {
+        return userService.save(userRegistrationDTO);
     }
 }

--- a/src/main/java/com/java/test/junior/controller/ProductController.java
+++ b/src/main/java/com/java/test/junior/controller/ProductController.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.io.IOException;
+import java.security.Principal;
 import java.util.List;
 
 /**
@@ -34,8 +35,8 @@ public class ProductController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "Create a new product")
-    public ProductDTO createProduct(@Valid @RequestBody ProductDTO productDTO) {
-        return productService.createProduct(productDTO);
+    public ProductDTO createProduct(@Valid @RequestBody ProductDTO productDTO, Principal principal) {
+        return productService.createProduct(productDTO, principal.getName());
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/java/test/junior/model/UserRegistrationDTO.java
+++ b/src/main/java/com/java/test/junior/model/UserRegistrationDTO.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 
 @Setter
 @Getter
-public class UserDTO {
+public class UserRegistrationDTO {
     @NotBlank(message = "Username is required")
     @Size(min = 4, message = "Username must be at least 4 characters")
     private String username;

--- a/src/main/java/com/java/test/junior/model/UserResponseDTO.java
+++ b/src/main/java/com/java/test/junior/model/UserResponseDTO.java
@@ -1,0 +1,12 @@
+package com.java.test.junior.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class UserResponseDTO {
+    private Long id;
+    private String username;
+    private String role;
+}

--- a/src/main/java/com/java/test/junior/service/ProductService.java
+++ b/src/main/java/com/java/test/junior/service/ProductService.java
@@ -19,7 +19,7 @@ public interface ProductService {
      * @param productDTO this product to be created
      * @return the product created from the database
      */
-    ProductDTO createProduct(ProductDTO productDTO);
+    ProductDTO createProduct(ProductDTO productDTO, String username);
 
     ProductDTO getProductById(Long id);
 

--- a/src/main/java/com/java/test/junior/service/ProductServiceImpl.java
+++ b/src/main/java/com/java/test/junior/service/ProductServiceImpl.java
@@ -14,6 +14,7 @@ import com.java.test.junior.mapper.UserMapper;
 import com.java.test.junior.model.Product;
 import com.java.test.junior.model.ProductDTO;
 import com.java.test.junior.model.User;
+import com.java.test.junior.model.UserResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.apache.ibatis.session.RowBounds;
 import org.postgresql.copy.CopyManager;
@@ -65,18 +66,22 @@ public class ProductServiceImpl implements ProductService {
     private final InteractionMapper interactionMapper;
     private final PasswordEncoder passwordEncoder;
     private final DataSource dataSource;
+    private final UserService userService;
+
     @Value("${app.admin.default-username}")
     private String defaultAdminUsername;
     @Value("${app.admin.default-password}")
     private String defaultAdminPassword;
 
+
     @Override
-    public ProductDTO createProduct(ProductDTO productDTO) {
+    public ProductDTO createProduct(ProductDTO productDTO, String username) {
         Product product = new Product();
         product.setName(productDTO.getName());
         product.setPrice(productDTO.getPrice());
         product.setDescription(productDTO.getDescription());
-        product.setUserId(1L);
+        Long userId = userService.findByUsername(username).getId();
+        product.setUserId(userId);
         product.setCreatedAt(LocalDateTime.now());
         product.setUpdatedAt(LocalDateTime.now());
         productMapper.insert(product);

--- a/src/main/java/com/java/test/junior/service/UserService.java
+++ b/src/main/java/com/java/test/junior/service/UserService.java
@@ -1,10 +1,10 @@
 package com.java.test.junior.service;
 
-import com.java.test.junior.model.UserDTO;
-import org.apache.ibatis.annotations.Mapper;
+import com.java.test.junior.model.UserRegistrationDTO;
+import com.java.test.junior.model.UserResponseDTO;
 
 
 public interface UserService {
-    UserDTO findByUsername(String username);
-    void save(UserDTO userDTO);
+    UserResponseDTO findByUsername(String username);
+    UserResponseDTO save(UserRegistrationDTO userRegistrationDTO);
 }

--- a/src/main/java/com/java/test/junior/service/UserServiceImpl.java
+++ b/src/main/java/com/java/test/junior/service/UserServiceImpl.java
@@ -4,7 +4,8 @@ import com.java.test.junior.exception.UserAlreadyExistsException;
 import com.java.test.junior.exception.UserNotFoundException;
 import com.java.test.junior.mapper.UserMapper;
 import com.java.test.junior.model.User;
-import com.java.test.junior.model.UserDTO;
+import com.java.test.junior.model.UserRegistrationDTO;
+import com.java.test.junior.model.UserResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -17,29 +18,31 @@ public class UserServiceImpl implements UserService {
     private final UserMapper userMapper;
 
     @Override
-    public UserDTO findByUsername(String username) {
+    public UserResponseDTO findByUsername(String username) {
         User user =  userMapper.findByUsername(username);
         if (user == null) {
             throw new UserNotFoundException("User not found");
         };
 
-        UserDTO dto = new UserDTO();
+        UserResponseDTO dto = new UserResponseDTO();
         dto.setUsername(user.getUsername());
-        dto.setPassword(user.getPassword());
+        dto.setId(user.getId());
+        dto.setRole(user.getRole());
         return dto;
     }
 
     @Override
-    public void save(UserDTO userDTO) {
+    public UserResponseDTO save(UserRegistrationDTO userRegistrationDTO) {
         try {
-            findByUsername(userDTO.getUsername());
+            findByUsername(userRegistrationDTO.getUsername());
             throw new UserAlreadyExistsException("User already exists!");
         } catch (UserNotFoundException e) {
             User userEntity = new User();
-            userEntity.setUsername(userDTO.getUsername());
-            userEntity.setPassword(passwordEncoder.encode(userDTO.getPassword()));
+            userEntity.setUsername(userRegistrationDTO.getUsername());
+            userEntity.setPassword(passwordEncoder.encode(userRegistrationDTO.getPassword()));
             userEntity.setRole("USER");
             userMapper.save(userEntity);
         }
+        return findByUsername(userRegistrationDTO.getUsername());
     }
 }

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -17,3 +17,6 @@ databaseChangeLog:
   - include:
       file: migration/V6__add_admin_constraint.sql
       relativeToChangelogFile: true
+  - include:
+      file: migration/V7__add_user_id_constraint.sql
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/migration/V7__add_user_id_constraint.sql
+++ b/src/main/resources/db/changelog/migration/V7__add_user_id_constraint.sql
@@ -1,0 +1,2 @@
+ALTER TABLE product
+ADD CONSTRAINT user_id_fk FOREIGN KEY (user_id) REFERENCES users (id);

--- a/src/test/java/com/java/test/junior/controller/AuthControllerIT.java
+++ b/src/test/java/com/java/test/junior/controller/AuthControllerIT.java
@@ -2,7 +2,7 @@ package com.java.test.junior.controller;
 
 import com.java.test.junior.BaseIntegrationTest;
 import com.java.test.junior.mapper.UserMapper;
-import com.java.test.junior.model.UserDTO;
+import com.java.test.junior.model.UserRegistrationDTO;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -20,7 +20,7 @@ class AuthControllerIT extends BaseIntegrationTest {
     private UserMapper userMapper;
 
     private TestRestTemplate getAuthRestTemplate(String username, String password) {
-        UserDTO user = new UserDTO();
+        UserRegistrationDTO user = new UserRegistrationDTO();
         user.setUsername(username);
         user.setPassword(password);
         restTemplate.postForEntity("/auth/register", user, Void.class);
@@ -29,7 +29,7 @@ class AuthControllerIT extends BaseIntegrationTest {
 
     @Test
     void testRegisterNewUserUnauthenticated() {
-        UserDTO user = new UserDTO();
+        UserRegistrationDTO user = new UserRegistrationDTO();
         user.setUsername("unauth_user");
         user.setPassword("pass123");
 
@@ -41,7 +41,7 @@ class AuthControllerIT extends BaseIntegrationTest {
 
     @Test
     void testRegisterWhileAuthenticated() {
-        UserDTO user = new UserDTO();
+        UserRegistrationDTO user = new UserRegistrationDTO();
         user.setUsername("auth_user");
         user.setPassword("pass123");
 
@@ -54,7 +54,7 @@ class AuthControllerIT extends BaseIntegrationTest {
 
     @Test
     void testRegisterSameUserAgainFails() {
-        UserDTO user = new UserDTO();
+        UserRegistrationDTO user = new UserRegistrationDTO();
         user.setUsername("duplicate_user");
         user.setPassword("pass123");
         restTemplate.postForEntity("/auth/register", user, Void.class);

--- a/src/test/java/com/java/test/junior/controller/ProductControllerIT.java
+++ b/src/test/java/com/java/test/junior/controller/ProductControllerIT.java
@@ -3,7 +3,7 @@ package com.java.test.junior.controller;
 import com.java.test.junior.BaseIntegrationTest;
 import com.java.test.junior.model.LoadingDTO;
 import com.java.test.junior.model.ProductDTO;
-import com.java.test.junior.model.UserDTO;
+import com.java.test.junior.model.UserRegistrationDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,7 +40,7 @@ public class ProductControllerIT extends BaseIntegrationTest {
     }
 
     private TestRestTemplate getAuthRestTemplate(String username, String password) {
-        UserDTO user = new UserDTO();
+        UserRegistrationDTO user = new UserRegistrationDTO();
         user.setUsername(username);
         user.setPassword(password);
         restTemplate.postForEntity("/auth/register", user, Void.class);


### PR DESCRIPTION
This pull request refactors user registration and product creation to improve clarity and ensure products are associated with the correct user. It introduces separate DTOs for user registration and user response, updates service interfaces and implementations accordingly, and enforces referential integrity between products and users at the database level. Integration and controller tests are updated to reflect these changes.

**User registration and DTO refactoring:**

* Renamed `UserDTO` to `UserRegistrationDTO` for registration requests, and introduced `UserResponseDTO` for responses, updating all relevant controller, service, and test usages. [[1]](diffhunk://#diff-f9e6ca8ca1545b3272c94b29a33fbd4ce7c23e04dd65cd761258281356d18742L10-R10) [[2]](diffhunk://#diff-fbe114d37ac5a88183bbab80e594724ebfd48acd9c8817a6d6c14139c877dc3cR1-R12) [[3]](diffhunk://#diff-1d5c78bd77766891640b0916e910c9ea6d457760fc7228572b52769f3505f872L3-R4) [[4]](diffhunk://#diff-25391a8684e08fd1c01b41534073cb5515164405c6ce404a0b75cd8872798310L7-R8) [[5]](diffhunk://#diff-25391a8684e08fd1c01b41534073cb5515164405c6ce404a0b75cd8872798310L20-R46) [[6]](diffhunk://#diff-46d7b8f8df7644436db48f3be2ae5d0510cffd4d43715abe2ebfce62179f9535L5-R5) [[7]](diffhunk://#diff-46d7b8f8df7644436db48f3be2ae5d0510cffd4d43715abe2ebfce62179f9535L23-R23) [[8]](diffhunk://#diff-46d7b8f8df7644436db48f3be2ae5d0510cffd4d43715abe2ebfce62179f9535L32-R32) [[9]](diffhunk://#diff-46d7b8f8df7644436db48f3be2ae5d0510cffd4d43715abe2ebfce62179f9535L44-R44) [[10]](diffhunk://#diff-46d7b8f8df7644436db48f3be2ae5d0510cffd4d43715abe2ebfce62179f9535L57-R57) [[11]](diffhunk://#diff-9496a59afd82e2da69863af07e1e32eba286be5722d1e7c94479670e52730357L6-R6) [[12]](diffhunk://#diff-9496a59afd82e2da69863af07e1e32eba286be5722d1e7c94479670e52730357L43-R43)

* Updated `UserService` and `UserServiceImpl` to use the new DTOs and return user details (including id and role) on registration and lookup. [[1]](diffhunk://#diff-6a2bd62868a1d212b53c8f34f841a57d88b4f8a3fe3b36e653334099e37e4b41L3-R9) [[2]](diffhunk://#diff-25391a8684e08fd1c01b41534073cb5515164405c6ce404a0b75cd8872798310L20-R46)

* Changed the `/auth/register` endpoint to return a `UserResponseDTO` instead of void.

**Product creation and user association:**

* Modified product creation so that the authenticated user's username is passed to the service, and the created product is associated with that user's ID. [[1]](diffhunk://#diff-63edfec3c191b368dc3e2d05eb1a18705c33f3c82cfef81f4feb6c952d2c9ed6R19) [[2]](diffhunk://#diff-63edfec3c191b368dc3e2d05eb1a18705c33f3c82cfef81f4feb6c952d2c9ed6L37-R39) [[3]](diffhunk://#diff-4c161b736a3d0ab4bc4c933f0530afa0d3bdd493c3f4d931ea55228db8821b4fL22-R22) [[4]](diffhunk://#diff-ae598862cba86814f7da5c098d53694d2ddc175771c8b7afdb4c489d016fa995R17) [[5]](diffhunk://#diff-ae598862cba86814f7da5c098d53694d2ddc175771c8b7afdb4c489d016fa995R69-R84)

**Database migration:**

* Added a migration to enforce a foreign key constraint from `product.user_id` to `users.id`, ensuring referential integrity. [[1]](diffhunk://#diff-98435174a7a84b3193aed747182cba0d05ce8a7f1da30c4d67e7ca82ae853f1bR20-R22) [[2]](diffhunk://#diff-1783421f6d5429ad907b65dc47332ec8a04ae9a18482d24948f7de6ecf3d2ee3R1-R2)

**IDE and configuration:**

* Added a new IntelliJ IDEA datasource configuration for local development.