### PR TITLE
fix: Restrict authenticated user from creating another account

### DIFF
--- a/src/main/java/com/java/test/junior/controller/AuthController.java
+++ b/src/main/java/com/java/test/junior/controller/AuthController.java
@@ -24,7 +24,8 @@ public class AuthController {
     @PostMapping("/register")
     @Operation(summary = "Register a new user")
     @ResponseStatus(HttpStatus.CREATED)
-    public UserResponseDTO register(@Valid @RequestBody UserRegistrationDTO userRegistrationDTO) {
-        return userService.save(userRegistrationDTO);
+    public UserResponseDTO register(@Valid @RequestBody UserRegistrationDTO userRegistrationDTO, Principal principal) {
+        String currentUsername = (principal != null) ? principal.getName() : null;
+        return userService.save(userRegistrationDTO, currentUsername);
     }
 }

--- a/src/main/java/com/java/test/junior/controller/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/java/test/junior/controller/handler/GlobalExceptionHandler.java
@@ -58,4 +58,10 @@ public class GlobalExceptionHandler {
     public ErrorResponse handlePageExceedsLimit(PageExceedsLimit ex) {
         return new ErrorResponse("BAD_REQUEST", ex.getMessage());
     }
+
+    @ExceptionHandler(IllegalActionException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleIllegalAction(IllegalActionException ex) {
+        return new ErrorResponse("BAD_REQUEST", ex.getMessage());
+    }
 }

--- a/src/main/java/com/java/test/junior/exception/IllegalActionException.java
+++ b/src/main/java/com/java/test/junior/exception/IllegalActionException.java
@@ -1,0 +1,7 @@
+package com.java.test.junior.exception;
+
+public class IllegalActionException extends RuntimeException {
+    public IllegalActionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/java/test/junior/service/UserService.java
+++ b/src/main/java/com/java/test/junior/service/UserService.java
@@ -6,5 +6,5 @@ import com.java.test.junior.model.UserResponseDTO;
 
 public interface UserService {
     UserResponseDTO findByUsername(String username);
-    UserResponseDTO save(UserRegistrationDTO userRegistrationDTO);
+    UserResponseDTO save(UserRegistrationDTO userRegistrationDTO, String username);
 }

--- a/src/main/java/com/java/test/junior/service/UserServiceImpl.java
+++ b/src/main/java/com/java/test/junior/service/UserServiceImpl.java
@@ -2,6 +2,7 @@ package com.java.test.junior.service;
 
 import com.java.test.junior.exception.UserAlreadyExistsException;
 import com.java.test.junior.exception.UserNotFoundException;
+import com.java.test.junior.exception.IllegalActionException;
 import com.java.test.junior.mapper.UserMapper;
 import com.java.test.junior.model.User;
 import com.java.test.junior.model.UserRegistrationDTO;
@@ -9,6 +10,7 @@ import com.java.test.junior.model.UserResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
 
 @Service
 @RequiredArgsConstructor
@@ -19,28 +21,34 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public UserResponseDTO findByUsername(String username) {
-        User user =  userMapper.findByUsername(username);
+        User user = userMapper.findByUsername(username);
         if (user == null) {
             throw new UserNotFoundException("User not found");
-        };
+        }
+        ;
 
         UserResponseDTO dto = new UserResponseDTO(user.getId(), user.getUsername(), user.getRole());
         return dto;
     }
-
     @Override
-    public UserResponseDTO save(UserRegistrationDTO userRegistrationDTO) {
+    public UserResponseDTO save(UserRegistrationDTO userRegistrationDTO, String username) {
         try {
             findByUsername(userRegistrationDTO.getUsername());
             throw new UserAlreadyExistsException("User already exists!");
         } catch (UserNotFoundException e) {
+            if (username != null && !username.isBlank()) {
+                throw new IllegalActionException("Cannot create multiple accounts");
+            }
+
             User userEntity = new User();
             userEntity.setUsername(userRegistrationDTO.getUsername());
             userEntity.setPassword(passwordEncoder.encode(userRegistrationDTO.getPassword()));
             userEntity.setRole("USER");
             userMapper.save(userEntity);
         }
+
         return findByUsername(userRegistrationDTO.getUsername());
     }
+
 
 }


### PR DESCRIPTION
This pull request introduces enhanced user registration logic and improved exception handling. The main change is to prevent already authenticated users from registering new accounts, and to provide a specific error for this scenario. Additionally, the codebase now includes a new custom exception and updates the global exception handler to respond appropriately.

User registration improvements:

* The `register` method in `AuthController` now accepts a `Principal`, checks if a user is already authenticated, and passes the current username to `UserService.save`. This prevents authenticated users from registering additional accounts.
* The `UserService.save` method and its implementation in `UserServiceImpl` have been updated to accept the current username. If a username is present (i.e., the user is authenticated), an `IllegalActionException` is thrown to enforce the new registration restriction. [[1]](diffhunk://#diff-6a2bd62868a1d212b53c8f34f841a57d88b4f8a3fe3b36e653334099e37e4b41L9-R9) [[2]](diffhunk://#diff-25391a8684e08fd1c01b41534073cb5515164405c6ce404a0b75cd8872798310L25-R53)

Exception handling enhancements:

* A new `IllegalActionException` class has been added to represent illegal actions, such as attempting to register while authenticated. [[1]](diffhunk://#diff-69190b37c373392bd04584b9aad0dd0658cae60e6754d6acd4e4b03a90043306R1-R7) [[2]](diffhunk://#diff-25391a8684e08fd1c01b41534073cb5515164405c6ce404a0b75cd8872798310R5)
* The global exception handler (`GlobalExceptionHandler`) now handles `IllegalActionException`, returning a `BAD_REQUEST` error response to the client.

Other minor changes:

* Minor formatting and import additions in `UserServiceImpl` for clarity and completeness.