### PR TITLE
refactor: Extract paths as static final variables

### DIFF
--- a/src/test/java/com/java/test/junior/controller/AppFlowIT.java
+++ b/src/test/java/com/java/test/junior/controller/AppFlowIT.java
@@ -6,33 +6,49 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 
 import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.springframework.test.web.servlet.result.StatusResultMatchersExtensionsKt.isEqualTo;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class AppFlowIT extends BaseIT {
+
     private static final String ALICE = "alice";
     private static final String ALICE_PASS = "alice123";
     private static final String JOHNY = "johny";
     private static final String JOHNY_PASS = "johny123";
     private static final String ADMIN = System.getProperty("ADMIN_USERNAME");
     private static final String ADMIN_PASS = System.getProperty("ADMIN_PASSWORD");
+
+    private static final String AUTH_REGISTER = "/auth/register";
+
+    private static final String PRODUCTS = "/products";
+    private static final String PRODUCTS_BY_ID = "/products/%d";
+    private static final String PRODUCTS_BY_NAME = "/products/name/%s";
+    private static final String PRODUCTS_LIKE = "/products/%d/like";
+    private static final String PRODUCTS_DISLIKE = "/products/%d/dislike";
+    private static final String PRODUCTS_PAGINATION = "/products?page=%d&page_size=%d";
+    private static final String PRODUCTS_LOADING = "/products/loading/products";
+
     private static Long productId;
+
+    private static final String PRODUCTS_URL = "https://raw.githubusercontent.com/MihaelaCatan04/java-test-junior/main/src/main/resources/products.csv";
+    private static final String PRODUCTS_CSV = "src/test/resources/products.csv";
+
     @Autowired
     private TestRestTemplate testRestTemplate;
+
 
     @Test
     @Order(1)
     void aliceRegistration() {
         UserRegistrationDTO request = new UserRegistrationDTO(ALICE, ALICE_PASS);
-        ResponseEntity<UserResponseDTO> response = testRestTemplate.postForEntity("/auth/register", request, UserResponseDTO.class);
+
+        ResponseEntity<UserResponseDTO> response =
+                testRestTemplate.postForEntity(AUTH_REGISTER, request, UserResponseDTO.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         assertNotNull(response.getBody());
@@ -44,7 +60,9 @@ public class AppFlowIT extends BaseIT {
     @Order(2)
     void johnyRegistration() {
         UserRegistrationDTO request = new UserRegistrationDTO(JOHNY, JOHNY_PASS);
-        ResponseEntity<UserResponseDTO> response = testRestTemplate.postForEntity("/auth/register", request, UserResponseDTO.class);
+
+        ResponseEntity<UserResponseDTO> response =
+                testRestTemplate.postForEntity(AUTH_REGISTER, request, UserResponseDTO.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         assertNotNull(response.getBody());
@@ -56,17 +74,25 @@ public class AppFlowIT extends BaseIT {
     @Order(3)
     void rejectDuplicateRegistration() {
         UserRegistrationDTO request = new UserRegistrationDTO(ALICE, "anotherPass");
-        ResponseEntity<ErrorResponse> response = testRestTemplate.postForEntity("/auth/register", request, ErrorResponse.class);
+
+        ResponseEntity<ErrorResponse> response =
+                testRestTemplate.postForEntity(AUTH_REGISTER, request, ErrorResponse.class);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
         assertNotNull(response.getBody());
         assertThat(response.getBody().getMessage()).isEqualTo("User already exists!");
     }
 
+    // ================= PRODUCTS =================
+
     @Test
     @Order(4)
     void unauthenticatedUserCannotCreateProduct() {
         ProductDTO request = new ProductDTO("Test Product", 100.00, "Test description");
-        ResponseEntity<ErrorResponse> response = testRestTemplate.postForEntity("/products", request, ErrorResponse.class);
+
+        ResponseEntity<ErrorResponse> response =
+                testRestTemplate.postForEntity(PRODUCTS, request, ErrorResponse.class);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
     }
 
@@ -74,30 +100,38 @@ public class AppFlowIT extends BaseIT {
     @Order(5)
     void aliceCreatesProduct() {
         ProductDTO request = new ProductDTO("Test Product", 100.00, "Test description");
-        ResponseEntity<ProductResponseDTO> response = testRestTemplate.withBasicAuth(ALICE, ALICE_PASS).postForEntity("/products", request, ProductResponseDTO.class);
+
+        ResponseEntity<ProductResponseDTO> response =
+                testRestTemplate.withBasicAuth(ALICE, ALICE_PASS)
+                        .postForEntity(PRODUCTS, request, ProductResponseDTO.class);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         assertThat(response.getBody().getName()).isEqualTo("Test Product");
         assertThat(response.getBody().getPrice()).isEqualTo(100.00);
         assertThat(response.getBody().getDescription()).isEqualTo("Test description");
         assertThat(response.getBody().getUsername()).isEqualTo(ALICE);
+
         productId = response.getBody().getId();
     }
 
     @Test
     @Order(6)
     void getProductById() {
-        ResponseEntity<ProductResponseDTO> response = testRestTemplate.withBasicAuth(ALICE, ALICE_PASS).getForEntity("/products/" + productId, ProductResponseDTO.class);
+        ResponseEntity<ProductResponseDTO> response =
+                testRestTemplate.withBasicAuth(ALICE, ALICE_PASS)
+                        .getForEntity(String.format(PRODUCTS_BY_ID, productId), ProductResponseDTO.class);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
-        assertThat(response.getBody().getName()).isEqualTo("Test Product");
-        assertThat(response.getBody().getPrice()).isEqualTo(100.00);
-        assertThat(response.getBody().getDescription()).isEqualTo("Test description");
         assertThat(response.getBody().getUsername()).isEqualTo(ALICE);
     }
 
     @Test
     @Order(7)
     void getNonexistentProductById() {
-        ResponseEntity<ErrorResponse> response = testRestTemplate.withBasicAuth(ALICE, ALICE_PASS).getForEntity("/products/100", ErrorResponse.class);
+        ResponseEntity<ErrorResponse> response =
+                testRestTemplate.withBasicAuth(ALICE, ALICE_PASS)
+                        .getForEntity(String.format(PRODUCTS_BY_ID, 100), ErrorResponse.class);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         assertThat(response.getBody().getMessage()).isEqualTo("Product not found");
     }
@@ -105,7 +139,10 @@ public class AppFlowIT extends BaseIT {
     @Test
     @Order(8)
     void getProductByNegativeId() {
-        ResponseEntity<ErrorResponse> response = testRestTemplate.withBasicAuth(ALICE, ALICE_PASS).getForEntity("/products/-1", ErrorResponse.class);
+        ResponseEntity<ErrorResponse> response =
+                testRestTemplate.withBasicAuth(ALICE, ALICE_PASS)
+                        .getForEntity(String.format(PRODUCTS_BY_ID, -1), ErrorResponse.class);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody().getMessage()).isEqualTo("Product id must be positive");
     }
@@ -113,8 +150,14 @@ public class AppFlowIT extends BaseIT {
     @Test
     @Order(9)
     void getProductByName() {
-        ResponseEntity<List<ProductResponseDTO>> response = testRestTemplate.withBasicAuth(ALICE, ALICE_PASS).exchange("/products/name/Test", HttpMethod.GET, null, new ParameterizedTypeReference<List<ProductResponseDTO>>() {
-        });
+        ResponseEntity<List<ProductResponseDTO>> response =
+                testRestTemplate.withBasicAuth(ALICE, ALICE_PASS)
+                        .exchange(
+                                String.format(PRODUCTS_BY_NAME, "Test"),
+                                HttpMethod.GET,
+                                null,
+                                new ParameterizedTypeReference<List<ProductResponseDTO>>() {}
+                        );
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
@@ -125,7 +168,11 @@ public class AppFlowIT extends BaseIT {
     void createProductsForPagination() {
         for (int i = 0; i < 4; i++) {
             ProductDTO request = new ProductDTO("Product " + i, 100.00, "Test description");
-            ResponseEntity<ProductResponseDTO> response = testRestTemplate.withBasicAuth(ALICE, ALICE_PASS).postForEntity("/products", request, ProductResponseDTO.class);
+
+            ResponseEntity<ProductResponseDTO> response =
+                    testRestTemplate.withBasicAuth(ALICE, ALICE_PASS)
+                            .postForEntity(PRODUCTS, request, ProductResponseDTO.class);
+
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         }
     }
@@ -133,21 +180,31 @@ public class AppFlowIT extends BaseIT {
     @Test
     @Order(11)
     void getFirstPage() {
-        ResponseEntity<PageResponse<ProductResponseDTO>> response = testRestTemplate.withBasicAuth(ALICE, ALICE_PASS).exchange("/products?page=1&page_size=2", HttpMethod.GET, null, new ParameterizedTypeReference<PageResponse<ProductResponseDTO>>() {
-        });
+        ResponseEntity<PageResponse<ProductResponseDTO>> response =
+                testRestTemplate.withBasicAuth(ALICE, ALICE_PASS)
+                        .exchange(
+                                String.format(PRODUCTS_PAGINATION, 1, 2),
+                                HttpMethod.GET,
+                                null,
+                                new ParameterizedTypeReference<PageResponse<ProductResponseDTO>>() {}
+                        );
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         PageResponse<ProductResponseDTO> body = response.getBody();
+
         assertThat(body).isNotNull();
         assertThat(body.getContent().size()).isEqualTo(2);
         assertThat(body.getTotalElements()).isEqualTo(5L);
         assertThat(body.getTotalPages()).isEqualTo(3);
-        ;
     }
 
     @Test
     @Order(12)
     void getInexistentPage() {
-        ResponseEntity<ErrorResponse> response = testRestTemplate.withBasicAuth(ALICE, ALICE_PASS).getForEntity("/products?page=100&page_size=2", ErrorResponse.class);
+        ResponseEntity<ErrorResponse> response =
+                testRestTemplate.withBasicAuth(ALICE, ALICE_PASS)
+                        .getForEntity(String.format(PRODUCTS_PAGINATION, 100, 2), ErrorResponse.class);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody().getMessage()).isEqualTo("Page 100 does not exist");
     }
@@ -155,7 +212,10 @@ public class AppFlowIT extends BaseIT {
     @Test
     @Order(13)
     void johnyLikesProduct() {
-        ResponseEntity<Integer> response = testRestTemplate.withBasicAuth(JOHNY, JOHNY_PASS).exchange("/products/" + productId + "/like", HttpMethod.POST, null, Integer.class);
+        ResponseEntity<Integer> response =
+                testRestTemplate.withBasicAuth(JOHNY, JOHNY_PASS)
+                        .exchange(String.format(PRODUCTS_LIKE, productId), HttpMethod.POST, null, Integer.class);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEqualTo(1);
     }
@@ -163,7 +223,10 @@ public class AppFlowIT extends BaseIT {
     @Test
     @Order(14)
     void johnyLikesAgainProduct() {
-        ResponseEntity<Integer> response = testRestTemplate.withBasicAuth(JOHNY, JOHNY_PASS).exchange("/products/" + productId + "/like", HttpMethod.POST, null, Integer.class);
+        ResponseEntity<Integer> response =
+                testRestTemplate.withBasicAuth(JOHNY, JOHNY_PASS)
+                        .exchange(String.format(PRODUCTS_LIKE, productId), HttpMethod.POST, null, Integer.class);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEqualTo(0);
     }
@@ -171,7 +234,10 @@ public class AppFlowIT extends BaseIT {
     @Test
     @Order(15)
     void johnyDislikesProduct() {
-        ResponseEntity<Integer> response = testRestTemplate.withBasicAuth(JOHNY, JOHNY_PASS).exchange("/products/" + productId + "/dislike", HttpMethod.POST, null, Integer.class);
+        ResponseEntity<Integer> response =
+                testRestTemplate.withBasicAuth(JOHNY, JOHNY_PASS)
+                        .exchange(String.format(PRODUCTS_DISLIKE, productId), HttpMethod.POST, null, Integer.class);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEqualTo(1);
     }
@@ -179,7 +245,10 @@ public class AppFlowIT extends BaseIT {
     @Test
     @Order(16)
     void johnyDislikesAgainProduct() {
-        ResponseEntity<Integer> response = testRestTemplate.withBasicAuth(JOHNY, JOHNY_PASS).exchange("/products/" + productId + "/dislike", HttpMethod.POST, null, Integer.class);
+        ResponseEntity<Integer> response =
+                testRestTemplate.withBasicAuth(JOHNY, JOHNY_PASS)
+                        .exchange(String.format(PRODUCTS_DISLIKE, productId), HttpMethod.POST, null, Integer.class);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEqualTo(0);
     }
@@ -187,17 +256,24 @@ public class AppFlowIT extends BaseIT {
     @Test
     @Order(17)
     void aliceAndJohnyDislikeProduct() {
-        ResponseEntity<Integer> response1 = testRestTemplate.withBasicAuth(ALICE, ALICE_PASS).exchange("/products/" + productId + "/dislike", HttpMethod.POST, null, Integer.class);
-        ResponseEntity<Integer> response2 = testRestTemplate.withBasicAuth(JOHNY, JOHNY_PASS).exchange("/products/" + productId + "/dislike", HttpMethod.POST, null, Integer.class);
-        assertThat(response1.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response2.getStatusCode()).isEqualTo(HttpStatus.OK);
+        ResponseEntity<Integer> response1 =
+                testRestTemplate.withBasicAuth(ALICE, ALICE_PASS)
+                        .exchange(String.format(PRODUCTS_DISLIKE, productId), HttpMethod.POST, null, Integer.class);
+
+        ResponseEntity<Integer> response2 =
+                testRestTemplate.withBasicAuth(JOHNY, JOHNY_PASS)
+                        .exchange(String.format(PRODUCTS_DISLIKE, productId), HttpMethod.POST, null, Integer.class);
+
         assertThat(response2.getBody()).isEqualTo(2);
     }
 
     @Test
     @Order(18)
     void likeNonexistentProduct() {
-        ResponseEntity<ErrorResponse> response = testRestTemplate.withBasicAuth(ALICE, ALICE_PASS).exchange("/products/100/like", HttpMethod.POST, null, ErrorResponse.class);
+        ResponseEntity<ErrorResponse> response =
+                testRestTemplate.withBasicAuth(ALICE, ALICE_PASS)
+                        .exchange(String.format(PRODUCTS_LIKE, 100), HttpMethod.POST, null, ErrorResponse.class);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         assertThat(response.getBody().getMessage()).isEqualTo("Product not found");
     }
@@ -206,7 +282,13 @@ public class AppFlowIT extends BaseIT {
     @Order(19)
     void johnyTriesToUpdateAlicesProduct() {
         ProductDTO updateRequest = new ProductDTO("New Name", 1000.00, "New Description from John!");
-        ResponseEntity<ErrorResponse> response = testRestTemplate.withBasicAuth(JOHNY, JOHNY_PASS).exchange("/products/" + productId, HttpMethod.PUT, new ResponseEntity<>(updateRequest, null, HttpStatus.OK), ErrorResponse.class);
+
+        HttpEntity<ProductDTO> entity = new HttpEntity<>(updateRequest);
+
+        ResponseEntity<ErrorResponse> response =
+                testRestTemplate.withBasicAuth(JOHNY, JOHNY_PASS)
+                        .exchange(String.format(PRODUCTS_BY_ID, productId), HttpMethod.PUT, entity, ErrorResponse.class);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 
@@ -214,7 +296,13 @@ public class AppFlowIT extends BaseIT {
     @Order(20)
     void aliceUpdatesAlicesProduct() {
         ProductDTO updateRequest = new ProductDTO("New Name", 1000.00, "New Description from Alice!");
-        ResponseEntity<ProductResponseDTO> response = testRestTemplate.withBasicAuth(ALICE, ALICE_PASS).exchange("/products/" + productId, HttpMethod.PUT, new ResponseEntity<>(updateRequest, null, HttpStatus.OK), ProductResponseDTO.class);
+
+        HttpEntity<ProductDTO> entity = new HttpEntity<>(updateRequest);
+
+        ResponseEntity<ProductResponseDTO> response =
+                testRestTemplate.withBasicAuth(ALICE, ALICE_PASS)
+                        .exchange(String.format(PRODUCTS_BY_ID, productId), HttpMethod.PUT, entity, ProductResponseDTO.class);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().getName()).isEqualTo("New Name");
         assertThat(response.getBody().getPrice()).isEqualTo(1000.00);
@@ -224,21 +312,30 @@ public class AppFlowIT extends BaseIT {
     @Test
     @Order(21)
     void johnyTriedToDeleteAlicesProduct() {
-        ResponseEntity<ErrorResponse> response = testRestTemplate.withBasicAuth(JOHNY, JOHNY_PASS).exchange("/products/" + productId, HttpMethod.DELETE, null, ErrorResponse.class);
+        ResponseEntity<ErrorResponse> response =
+                testRestTemplate.withBasicAuth(JOHNY, JOHNY_PASS)
+                        .exchange(String.format(PRODUCTS_BY_ID, productId), HttpMethod.DELETE, null, ErrorResponse.class);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 
     @Test
     @Order(22)
     void aliceDeletesAlicesProduct() {
-        ResponseEntity<Void> response = testRestTemplate.withBasicAuth(ALICE, ALICE_PASS).exchange("/products/" + productId, HttpMethod.DELETE, null, Void.class);
+        ResponseEntity<Void> response =
+                testRestTemplate.withBasicAuth(ALICE, ALICE_PASS)
+                        .exchange(String.format(PRODUCTS_BY_ID, productId), HttpMethod.DELETE, null, Void.class);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
     @Test
     @Order(23)
     void getNonexistentProductAfterDelete() {
-        ResponseEntity<ErrorResponse> response = testRestTemplate.withBasicAuth(ALICE, ALICE_PASS).getForEntity("/products/" + productId, ErrorResponse.class);
+        ResponseEntity<ErrorResponse> response =
+                testRestTemplate.withBasicAuth(ALICE, ALICE_PASS)
+                        .getForEntity(String.format(PRODUCTS_BY_ID, productId), ErrorResponse.class);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         assertThat(response.getBody().getMessage()).isEqualTo("Product not found");
     }
@@ -246,23 +343,24 @@ public class AppFlowIT extends BaseIT {
     @Test
     @Order(24)
     void loadProductsFromCSV() {
-        LoadingDTO loadingDTO = new LoadingDTO("src/test/resources/products.csv");
+        LoadingDTO loadingDTO = new LoadingDTO(PRODUCTS_CSV);
 
-        ResponseEntity<Void> response = testRestTemplate.withBasicAuth(ADMIN, ADMIN_PASS).postForEntity("/products/loading/products", loadingDTO, Void.class);
+        ResponseEntity<Void> response =
+                testRestTemplate.withBasicAuth(ADMIN, ADMIN_PASS)
+                        .postForEntity(PRODUCTS_LOADING, loadingDTO, Void.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     }
-
 
     @Test
     @Order(25)
     void loadProductsFromURL() {
-        LoadingDTO loadingDTO = new LoadingDTO("https://raw.githubusercontent.com/MihaelaCatan04/java-test-junior/main/src/main/resources/products.csv");
+        LoadingDTO loadingDTO = new LoadingDTO(PRODUCTS_URL);
 
-        ResponseEntity<Void> response = testRestTemplate.withBasicAuth(ADMIN, ADMIN_PASS).postForEntity("/products/loading/products", loadingDTO, Void.class);
+        ResponseEntity<Void> response =
+                testRestTemplate.withBasicAuth(ADMIN, ADMIN_PASS)
+                        .postForEntity(PRODUCTS_LOADING, loadingDTO, Void.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     }
-
-
 }


### PR DESCRIPTION
This pull request refactors the `AppFlowIT` integration test class to improve maintainability and readability by introducing constants for endpoint URLs and reusing them throughout the tests. Additionally, it standardizes the construction of HTTP requests, reducing duplication and potential errors.

Key improvements include:

**Test maintainability and readability:**

* Introduced constants for all endpoint paths (e.g., `AUTH_REGISTER`, `PRODUCTS`, `PRODUCTS_BY_ID`, etc.), replacing hardcoded URL strings throughout the test methods.
* Added constants for product data sources (`PRODUCTS_URL`, `PRODUCTS_CSV`) to simplify test data management.

**HTTP request consistency:**

* Refactored all HTTP requests to use the new constants and `String.format` where appropriate, ensuring consistency and reducing repetition in test setup. [[1]](diffhunk://#diff-13917d95709db90123e1705d3282d5ea4ea11448da59ea4ce46254d078efa614L47-R65) [[2]](diffhunk://#diff-13917d95709db90123e1705d3282d5ea4ea11448da59ea4ce46254d078efa614L59-R160) [[3]](diffhunk://#diff-13917d95709db90123e1705d3282d5ea4ea11448da59ea4ce46254d078efa614L128-R276) [[4]](diffhunk://#diff-13917d95709db90123e1705d3282d5ea4ea11448da59ea4ce46254d078efa614L209-R305) [[5]](diffhunk://#diff-13917d95709db90123e1705d3282d5ea4ea11448da59ea4ce46254d078efa614L227-L267)
* Improved the construction of `HttpEntity` objects for PUT requests, making the code more idiomatic and easier to follow.

**General code cleanup:**

* Removed unused imports and cleaned up unnecessary code, further improving the clarity of the test class.